### PR TITLE
fix:AppRun.wrapped: 11: source: not found

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -8,10 +8,12 @@ on:
     branches: [ "trunk" ]
     paths:
       - '.github/workflows/appimage.yml'
+      - 'AppRun'
   pull_request:
     branches: [ "trunk" ]
     paths:
       - '.github/workflows/appimage.yml'
+      - 'AppRun'
 
 env:
   MINISIGN_VERSION: '0.10'

--- a/AppRun
+++ b/AppRun
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env bash
 
 # The purpose of this custom AppRun script is
 # to allow symlinking the AppImage and invoking
@@ -8,7 +8,6 @@
 set -e
 
 HERE="$(readlink -f "$(dirname "$0")")"
-source "$HERE"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
 BINARY_NAME=$(basename "$ARGV0")
 
 if [ "$BINARY_NAME" = "pyrogenesis" -o "$BINARY_NAME" = "0ad" ] ; then


### PR DESCRIPTION
This happens on shells that don't have a `source` command.

Reported by dandaman46 in https://wildfiregames.com/forum/topic/91547-how-to-make-a-0ad-appimage/?do=findComment&comment=525445 using Debian bullseye

@TheAssassin Is there a particular reason linuxdeploy uses `bash` for the shebang instead of just 'sh' and uses `source` instead of '.' when importing the gtk plugin when creating the AppRun script?

https://stackoverflow.com/a/20097303/6838037