### PR TITLE
add vulkan libs to AppImage (#19)

### DIFF
--- a/workflow.sh
+++ b/workflow.sh
@@ -198,6 +198,8 @@ ionice -c3 $TOOLS_DIR/squashfs-root/AppRun -d $APPDIR/usr/share/applications/0ad
   --icon-filename=0ad \
   --executable $APPDIR/usr/bin/pyrogenesis \
   --library=/usr/lib/x86_64-linux-gnu/libthai.so.0 \
+  --library=/usr/lib/x86_64-linux-gnu/libvulkan.so \
+  --library=/usr/lib/x86_64-linux-gnu/libvulkan_intel.so \
   --custom-apprun=$WORKSPACE/AppRun \
   --appdir $APPDIR \
   --output appimage \


### PR DESCRIPTION
@Stan @tuxayo This probably won't work. I don't know how 0ad is loading vulkan, or what libraries are doing it (i.e., when I enter `ldd pyrogenesis`, libvulkan doesn't show as a dependency).