### PR TITLE
Made the AppImage updatable & get rid of libfuse2 dependency

### DIFF
--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -222,8 +222,7 @@ TAG="latest"
 [ -z "$GITHUB_REPOSITORY_OWNER" ] && GITHUB_REPOSITORY_OWNER="0ad-matters"
 UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|$REPO|$TAG|*$ARCH.AppImage.zsync"
 
-appimagetool --appimage-extract-and-run \
-	--comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
 	-u "$UPINFO" \
 	"$APPDIR" "$OUT_APPIMAGE"
 

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -222,7 +222,7 @@ TAG="latest"
 [ -z "$GITHUB_REPOSITORY_OWNER" ] && GITHUB_REPOSITORY_OWNER="0ad-matters"
 UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|$REPO|$TAG|*$ARCH.AppImage.zsync"
 
-./appimagetool --appimage-extract-and-run \
+appimagetool --appimage-extract-and-run \
 	--comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
 	-u "$UPINFO" \
 	"$APPDIR" "$OUT_APPIMAGE"

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -209,13 +209,28 @@ linuxdeploy \
     --library=/usr/lib/$ARCH-linux-gnu/libthai.so.0 \
     --custom-apprun=$WORKSPACE/AppRun \
     --appdir $APPDIR \
-    --output appimage \
     --plugin gtk
+fi
+
+# Use appimagetool from https://github.com/AppImage/appimagetool
+if [ ! -f ./appimagetool ]; then
+	echo "-----------------------------------------------------------------------------"
+	echo "◆ Downloading \"appimagetool\" from https://github.com/AppImage/appimagetool"
+	echo "-----------------------------------------------------------------------------"
+	curl -#Lo appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-"$ARCH".AppImage && chmod a+x appimagetool
 fi
 
 DATE_STR=$(date +%y%m%d%H%M)
 OUT_APPIMAGE="0ad-$VERSION-$DATE_STR-$ARCH.AppImage"
-mv 0_A.D.-$VERSION-$ARCH.AppImage $OUT_APPIMAGE
+
+REPO="0ad-appimage"
+TAG="latest"
+UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|$REPO|$TAG|*$ARCH.AppImage.zsync"
+
+ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+	-u "$UPINFO" \
+	"$APPDIR" "$OUT_APPIMAGE"
+
 sha1sum $OUT_APPIMAGE > "$OUT_APPIMAGE.sha1sum"
 cat "$OUT_APPIMAGE.sha1sum"
 

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -214,14 +214,6 @@ linuxdeploy \
     --plugin gtk
 fi
 
-# Use appimagetool from https://github.com/AppImage/appimagetool
-if [ ! -f ./appimagetool ]; then
-	echo "-----------------------------------------------------------------------------"
-	echo "◆ Downloading \"appimagetool\" from https://github.com/AppImage/appimagetool"
-	echo "-----------------------------------------------------------------------------"
-	curl -#Lo appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-"$ARCH".AppImage && chmod a+x appimagetool
-fi
-
 DATE_STR=$(date +%y%m%d%H%M)
 OUT_APPIMAGE="0ad-$VERSION-$DATE_STR-$ARCH.AppImage"
 

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -227,7 +227,8 @@ REPO="0ad-appimage"
 TAG="latest"
 UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|$REPO|$TAG|*$ARCH.AppImage.zsync"
 
-./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+./appimagetool --appimage-extract-and-run \
+	--comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
 	-u "$UPINFO" \
 	"$APPDIR" "$OUT_APPIMAGE"
 

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -45,6 +45,7 @@ sudo DEBIAN_FRONTEND=noninteractive -i sh -c "apt update && apt -y upgrade && \
     cmake \
     curl \
     $CC \
+    desktop-file-utils \
     libboost-dev    \
     libboost-filesystem-dev \
     libboost-system-dev   \
@@ -68,7 +69,8 @@ sudo DEBIAN_FRONTEND=noninteractive -i sh -c "apt update && apt -y upgrade && \
     patchelf \
     python3 \
     rustc   \
-    zlib1g-dev"
+    zlib1g-dev \
+    zsync"
 
 # needed for spidermonkey build
 #export SHELL=/bin/bash

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -227,7 +227,7 @@ REPO="0ad-appimage"
 TAG="latest"
 UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|$REPO|$TAG|*$ARCH.AppImage.zsync"
 
-ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
 	-u "$UPINFO" \
 	"$APPDIR" "$OUT_APPIMAGE"
 

--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -227,6 +227,7 @@ OUT_APPIMAGE="0ad-$VERSION-$DATE_STR-$ARCH.AppImage"
 
 REPO="0ad-appimage"
 TAG="latest"
+[ -z "$GITHUB_REPOSITORY_OWNER" ] && GITHUB_REPOSITORY_OWNER="0ad-matters"
 UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|$REPO|$TAG|*$ARCH.AppImage.zsync"
 
 ./appimagetool --appimage-extract-and-run \


### PR DESCRIPTION
fix https://github.com/0ad-matters/0ad-appimage/issues/33

fix https://github.com/0ad-matters/0ad-appimage/issues/9

--------------------------

@andy5995 note that the last workflow has failed, since I removed the re-downloaded appimagetool

You need to redirect the ./appimagetool reference to the right path or this would not work.

Thanks for your attention.